### PR TITLE
Potential fix for code scanning alert no. 2: Type confusion through parameter tampering

### DIFF
--- a/backend/routes/upload.js
+++ b/backend/routes/upload.js
@@ -22,7 +22,7 @@ async function uploadToSupabaseStorage(file, folder = "mobile-repair") {
 // Upload multiple images (max 5)
 router.post("/images", auth, upload.array("images", 5), async (req, res) => {
   try {
-    if (!req.files || req.files.length === 0 || req.files.length > 5) {
+    if (!Array.isArray(req.files) || req.files.length === 0 || req.files.length > 5) {
       return res.status(400).json({ message: "Upload 1-5 images only" })
     }
     const imageUrls = []


### PR DESCRIPTION
Potential fix for [https://github.com/Sushanth20092/mobile_repair/security/code-scanning/2](https://github.com/Sushanth20092/mobile_repair/security/code-scanning/2)

To fix the issue, we will explicitly check the type of `req.files` to ensure it is an array before proceeding with the logic. If `req.files` is not an array, we will return a `400 Bad Request` response with an appropriate error message. This ensures that the code does not proceed with unexpected types, preventing type confusion attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
